### PR TITLE
fixed documentation for --ter.punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Usage: program <module_name> [options...]
 === TER ===
 -T [--ter.shiftCost]              Shift cost for TER 
 -d [--ter.maxShiftDistance]       Maximum shift distance for TER 
--P [--ter.punctuation]            Use punctuation in TER? 
+-P [--ter.punctuation]            Ignore punctuation in TER? 
 -b [--ter.beamWidth]              Beam width for TER 
 -B [--ter.substituteCost]         Substitute cost for TER 
 -D [--ter.deleteCost]             Delete cost for TER 

--- a/src/multeval/metrics/TER.java
+++ b/src/multeval/metrics/TER.java
@@ -11,7 +11,7 @@ import com.google.common.base.*;
 
 public class TER extends Metric<IntStats> {
 
-  @Option(shortName = "P", longName = "ter.punctuation", usage = "Use punctuation in TER?", defaultValue = "false")
+  @Option(shortName = "P", longName = "ter.punctuation", usage = "Ignore punctuation in TER?", defaultValue = "false")
   boolean punctuation;
 
   @Option(shortName = "b", longName = "ter.beamWidth", usage = "Beam width for TER", defaultValue = "20")


### PR DESCRIPTION
- consistency with [tercom documentation](http://www.cs.umd.edu/~snover/tercom/) which states "-P no punctuations, default is with punctuations."
- TER score increases with --ter.punctuation true, and "removing the punctuation typically worsens the scores, since punctuation is easy to translate" [Mauro Cettolo, private communication]
