### PR TITLE
Make multeval.sh run from arbitrary working directory - via build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -42,14 +42,17 @@
       <zipfileset src="lib/jannopts.jar" excludes="META-INF/*" />
       <zipfileset src="lib/guava-11.0.jar" excludes="META-INF/*" />
 
-<!-- JARs are braindead regarding CLASSPATH
       <manifest>
-	<attribute name="Main-Class"
-		   value="multeval.MultEval"/>
+        <attribute name="Main-Class"
+		       value="multeval.MultEval"/>
+        <attribute name="Implementation-Version" 
+              value="${version}"/> 
+<!-- JARs are braindead regarding CLASSPATH
 	<attribute name="Class-Path"
 		   value="lib/tercom-0.7.26.jar:lib/meteor-1.2/meteor-1.2.jar"/>
-      </manifest>
 -->
+      </manifest>
+
     </jar>
   </target>
 </project>

--- a/src/multeval/MultEval.java
+++ b/src/multeval/MultEval.java
@@ -70,19 +70,19 @@ public class MultEval {
 		return threads;
 	}
 
-        private static String loadVersion() throws IOException {
-            Properties props = new Properties();
-            FileInputStream in = new FileInputStream("constants");
-            props.load(in);
-            in.close();
-            String version = props.getProperty("version");
-            return version;
-        }
+//        private static String loadVersion() throws IOException {
+//            Properties props = new Properties();
+//            FileInputStream in = new FileInputStream("constants");
+//            props.load(in);
+//            in.close();
+//            String version = props.getProperty("version");
+//            return version;
+//        }
 
 	public static void main(String[] args) throws ConfigurationException, IOException,
 			InterruptedException {
 
-            String version = MultEval.class.getPackage().getImplementationVersion(); //loadVersion();
+            String version = MultEval.class.getPackage().getImplementationVersion();
             System.err.println(String.format("MultEval V%s\n", version) +
                                "By Jonathan Clark\n" +
                                "Using Libraries: METEOR (Michael Denkowski) and TER (Matthew Snover)\n");

--- a/src/multeval/MultEval.java
+++ b/src/multeval/MultEval.java
@@ -82,7 +82,7 @@ public class MultEval {
 	public static void main(String[] args) throws ConfigurationException, IOException,
 			InterruptedException {
 
-            String version = loadVersion();
+            String version = MultEval.class.getPackage().getImplementationVersion(); //loadVersion();
             System.err.println(String.format("MultEval V%s\n", version) +
                                "By Jonathan Clark\n" +
                                "Using Libraries: METEOR (Michael Denkowski) and TER (Matthew Snover)\n");


### PR DESCRIPTION
This fixes a regression introduced in commit [cb6a52](https://github.com/jhclark/multeval/commit/cb6a523f476dafede2a9ff8963638dcdde4f20b3), following a code example on [rgagnon.com](http://www.rgagnon.com/javadetails/java-0532.html), as mentioned on issue #9.

It looks like `MultEval.loadVersion()` is only ever called from `MultEval.main()`, so this looks relatively safe to change.
